### PR TITLE
Store DM rumors without re-signing

### DIFF
--- a/crates/coop/src/views/chat/mod.rs
+++ b/crates/coop/src/views/chat/mod.rs
@@ -166,7 +166,7 @@ impl Chat {
                 match signal {
                     RoomSignal::NewMessage((gift_wrap_id, event)) => {
                         let gift_wrap_id = gift_wrap_id.to_owned();
-                        let message = Message::user(event);
+                        let message = Message::user(event.clone());
 
                         cx.spawn_in(window, async move |this, cx| {
                             let states = app_state();
@@ -423,8 +423,8 @@ impl Chat {
     }
 
     /// Convert and insert a vector of nostr events into the chat panel
-    fn insert_messages(&mut self, events: Vec<Event>, cx: &mut Context<Self>) {
-        for event in events.into_iter() {
+    fn insert_messages(&mut self, events: Vec<UnsignedEvent>, cx: &mut Context<Self>) {
+        for event in events {
             let m = Message::user(event);
             // Bulk inserting messages, so no need to scroll to the latest message
             self.insert_message(m, false, cx);

--- a/crates/registry/src/lib.rs
+++ b/crates/registry/src/lib.rs
@@ -9,7 +9,6 @@ use fuzzy_matcher::FuzzyMatcher;
 use gpui::{
     App, AppContext, AsyncApp, Context, Entity, EventEmitter, Global, Task, WeakEntity, Window,
 };
-use itertools::Itertools;
 use nostr_sdk::prelude::*;
 use room::RoomKind;
 use settings::AppSettings;
@@ -338,63 +337,64 @@ impl Registry {
             let public_key = signer.get_public_key().await?;
             let contacts = client.database().contacts_public_keys(public_key).await?;
 
-            // Get messages sent by the user
-            let sent = Filter::new()
-                .kind(Kind::PrivateDirectMessage)
-                .author(public_key);
+            let authored_filter = Filter::new()
+                .kind(Kind::ApplicationSpecificData)
+                .custom_tag(
+                    SingleLetterTag::lowercase(Alphabet::A),
+                    public_key.to_hex(),
+                );
 
-            // Get messages received by the user
-            let recv = Filter::new()
-                .kind(Kind::PrivateDirectMessage)
-                .pubkey(public_key);
+            let addressed_filter = Filter::new()
+                .kind(Kind::ApplicationSpecificData)
+                .custom_tag(SingleLetterTag::lowercase(Alphabet::P), public_key);
 
-            let sent_events = client.database().query(sent).await?;
-            let recv_events = client.database().query(recv).await?;
-            let events = sent_events.merge(recv_events);
+            let authored = client.database().query(authored_filter).await?;
+            let addressed = client.database().query(addressed_filter).await?;
+            let events = authored.merge(addressed);
 
             let mut rooms: HashSet<Room> = HashSet::new();
+            let mut grouped: HashMap<u64, Vec<UnsignedEvent>> = HashMap::new();
 
             // Process each event and group by room hash
-            for event in events
-                .into_iter()
-                .sorted_by_key(|event| Reverse(event.created_at))
-                .filter(|ev| ev.tags.public_keys().peekable().peek().is_some())
-            {
-                // Parse the room from the nostr event
-                let room = Room::from(&event);
+            for raw in events.into_iter() {
+                match UnsignedEvent::from_json(&raw.content) {
+                    Ok(rumor) => {
+                        if rumor.tags.public_keys().peekable().peek().is_some() {
+                            grouped.entry(rumor.uniq_id()).or_default().push(rumor);
+                        }
+                    }
+                    Err(e) => log::warn!("Failed to parse stored rumor: {e}"),
+                }
+            }
 
-                // Skip if the room is already in the set
+            for (_room_id, mut messages) in grouped.into_iter() {
+                messages.sort_by_key(|m| Reverse(m.created_at));
+
+                let Some(latest) = messages.first() else {
+                    continue;
+                };
+
+                let mut room = Room::from(latest);
+
                 if rooms.iter().any(|r| r.id == room.id) {
                     continue;
                 }
 
-                // Get all public keys from the event's tags
                 let mut public_keys: Vec<PublicKey> = room.members().to_vec();
                 public_keys.retain(|pk| pk != &public_key);
 
-                // Bypass screening flag
-                let mut bypassed = false;
+                let user_sent = messages.iter().any(|m| m.pubkey == public_key);
 
-                // If the user has enabled bypass screening in settings,
-                // check if any of the room's members are contacts of the current user
+                let mut bypassed = false;
                 if bypass_setting {
                     bypassed = public_keys.iter().any(|k| contacts.contains(k));
                 }
 
-                // Check if the current user has sent at least one message to this room
-                let filter = Filter::new()
-                    .kind(Kind::PrivateDirectMessage)
-                    .author(public_key)
-                    .pubkeys(public_keys);
-
-                // If current user has sent a message at least once, mark as ongoing
-                let is_ongoing = client.database().count(filter).await.unwrap_or(1) >= 1;
-
-                if is_ongoing || bypassed {
-                    rooms.insert(room.kind(RoomKind::Ongoing));
-                } else {
-                    rooms.insert(room);
+                if user_sent || bypassed {
+                    room = room.kind(RoomKind::Ongoing);
                 }
+
+                rooms.insert(room);
             }
 
             Ok(rooms)
@@ -482,7 +482,7 @@ impl Registry {
     pub fn event_to_message(
         &mut self,
         gift_wrap: EventId,
-        event: Event,
+        event: UnsignedEvent,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -495,11 +495,13 @@ impl Registry {
 
         if let Some(room) = self.rooms.iter().find(|room| room.read(cx).id == id) {
             let is_new_event = event.created_at > room.read(cx).created_at;
+            let created_at = event.created_at;
+            let event_for_emit = event.clone();
 
             // Update room
             room.update(cx, |this, cx| {
                 if is_new_event {
-                    this.set_created_at(event.created_at, cx);
+                    this.set_created_at(created_at, cx);
                 }
 
                 // Set this room is ongoing if the new message is from current user
@@ -508,8 +510,9 @@ impl Registry {
                 }
 
                 // Emit the new message to the room
+                let event_to_emit = event_for_emit.clone();
                 cx.defer_in(window, move |this, _window, cx| {
-                    this.emit_message(gift_wrap, event, cx);
+                    this.emit_message(gift_wrap, event_to_emit, cx);
                 });
             });
 


### PR DESCRIPTION
### Warning

Hallucinations may be present, or all encompassing. Professional dev review has not been performed. 

### PR Summary
---
Kept NIP‑17 kind‑14 rumors unsigned by storing them verbatim as JSON inside a local Kind::ApplicationSpecificData wrapper; the wrapper is signed only to satisfy LMDB, and never leaves the client.
  - Added helper tags (a=author hex, p=recipients, c=conversation hash, e=rumor ID) so room loading and inbox queries remain efficient;
    registry/chat now deserialize the wrapper back into UnsignedEvents before rendering.
  - Room discovery and message history now run off the new cache format, eliminating the bogus random signatures that previously broke author attribution.

Should solve https://github.com/lumehq/coop/issues/191.


===
### Pre-PR Problem Statement

```
 Problem
  In the current code the DM rumor (a kind‑14 event that should stay unsigned under NIP‑17) gets re-signed with a freshly generated key before we cache it. That issues a bogus Schnorr signature, leaves the stored pubkey pointing at a random key, and breaks author-based lookups—queries looking for the real sender miss their own messages because the stored record claims someone else authored them.